### PR TITLE
Support client storage of column widths

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -141,6 +141,10 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    * @default 35
    */
   summaryRowHeight?: Maybe<number>;
+  /**
+   * The client-managed width of each resized column in pixels
+   */
+  resizedColumnWidths?: ReadonlyMap<string, number>;
 
   /**
    * Feature props
@@ -172,7 +176,7 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
   /** Called when the grid is scrolled */
   onScroll?: Maybe<(event: React.UIEvent<HTMLDivElement>) => void>;
   /** Called when a column is resized */
-  onColumnResize?: Maybe<(idx: number, width: number) => void>;
+  onColumnResize?: Maybe<(idx: number, width: number, isComplete?: boolean) => void>;
   /** Called when a column is reordered */
   onColumnsReorder?: Maybe<(sourceColumnKey: string, targetColumnKey: string) => void>;
 
@@ -215,6 +219,7 @@ function DataGrid<R, SR, K extends Key>(
     rowHeight: rawRowHeight,
     headerRowHeight: rawHeaderRowHeight,
     summaryRowHeight: rawSummaryRowHeight,
+    resizedColumnWidths: rawResizedColumnWidths,
     // Feature props
     selectedRows,
     onSelectedRowsChange,
@@ -273,7 +278,7 @@ function DataGrid<R, SR, K extends Key>(
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
   const [resizedColumnWidths, setResizedColumnWidths] = useState(
-    (): ReadonlyMap<string, number> => new Map()
+    (): ReadonlyMap<string, number> => new Map(rawResizedColumnWidths)
   );
   const [measuredColumnWidths, setMeasuredColumnWidths] = useState(
     (): ReadonlyMap<string, number> => new Map()
@@ -286,10 +291,13 @@ function DataGrid<R, SR, K extends Key>(
   const getColumnWidth = useCallback(
     (column: CalculatedColumn<R, SR>) => {
       return (
-        resizedColumnWidths.get(column.key) ?? measuredColumnWidths.get(column.key) ?? column.width
+        rawResizedColumnWidths?.get(column.key) ??
+        resizedColumnWidths.get(column.key) ??
+        measuredColumnWidths.get(column.key) ??
+        column.width
       );
     },
-    [measuredColumnWidths, resizedColumnWidths]
+    [measuredColumnWidths, rawResizedColumnWidths, resizedColumnWidths]
   );
 
   const [gridRef, gridWidth, gridHeight] = useGridDimensions();

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -122,16 +122,20 @@ export default function HeaderCell<R, SR>({
     const headerCell = currentTarget.parentElement!;
     const { right, left } = headerCell.getBoundingClientRect();
     const offset = isRtl ? event.clientX - left : right - event.clientX;
+    let lastWidth = 0;
 
     function onPointerMove(event: PointerEvent) {
       const { right, left } = headerCell.getBoundingClientRect();
       const width = isRtl ? right + offset - event.clientX : event.clientX + offset - left;
       if (width > 0) {
-        onColumnResize(column, clampColumnWidth(width, column));
+        lastWidth = clampColumnWidth(width, column);
+        onColumnResize(column, lastWidth);
       }
     }
 
     function onLostPointerCapture() {
+      // let client know that resize is complete
+      onColumnResize(column, lastWidth, true);
       currentTarget.removeEventListener('pointermove', onPointerMove);
       currentTarget.removeEventListener('lostpointercapture', onLostPointerCapture);
     }
@@ -187,7 +191,7 @@ export default function HeaderCell<R, SR>({
   }
 
   function onDoubleClick() {
-    onColumnResize(column, 'max-content');
+    onColumnResize(column, 'max-content', true);
   }
 
   function handleFocus(event: React.FocusEvent<HTMLDivElement>) {

--- a/src/HeaderRow.tsx
+++ b/src/HeaderRow.tsx
@@ -17,7 +17,11 @@ type SharedDataGridProps<R, SR, K extends React.Key> = Pick<
 export interface HeaderRowProps<R, SR, K extends React.Key> extends SharedDataGridProps<R, SR, K> {
   rowIdx: number;
   columns: readonly CalculatedColumn<R, SR>[];
-  onColumnResize: (column: CalculatedColumn<R, SR>, width: number | 'max-content') => void;
+  onColumnResize: (
+    column: CalculatedColumn<R, SR>,
+    width: number | 'max-content',
+    isComplete?: boolean
+  ) => void;
   selectCell: (position: Position) => void;
   lastFrozenColumnIndex: number;
   selectedCellIdx: number | undefined;

--- a/src/hooks/useColumnWidths.ts
+++ b/src/hooks/useColumnWidths.ts
@@ -65,7 +65,11 @@ export function useColumnWidths<R, SR>(
     });
   }
 
-  function handleColumnResize(column: CalculatedColumn<R, SR>, nextWidth: number | 'max-content') {
+  function handleColumnResize(
+    column: CalculatedColumn<R, SR>,
+    nextWidth: number | 'max-content',
+    isComplete = false
+  ) {
     const { key: resizingKey } = column;
     const newTemplateColumns = [...templateColumns];
     const columnsToMeasure: string[] = [];
@@ -96,7 +100,7 @@ export function useColumnWidths<R, SR>(
       updateMeasuredWidths(columnsToMeasure);
     });
 
-    onColumnResize?.(column.idx, measuredWidth);
+    onColumnResize?.(column.idx, measuredWidth, isComplete);
   }
 
   return {

--- a/test/column/resizable.test.tsx
+++ b/test/column/resizable.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 
 import type { Column } from '../../src';
+import DataGrid from '../../src';
 import { resizeHandleClassname } from '../../src/HeaderCell';
 import { getGrid, getHeaderCells, setup } from '../utils';
 
@@ -102,5 +103,15 @@ test('should use the minWidth if specified', () => {
   const [, col2] = getHeaderCells();
   expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 200px' });
   resize({ column: col2, clientXStart: 295, clientXEnd: 100, rect: { right: 300, left: 100 } });
+  expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 100px' });
+});
+
+test('client can update columns widths', () => {
+  const props = { columns, rows: [] };
+  const { rerender } = setup(props);
+  expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 200px' });
+  const resizedColumnWidths = new Map<string, number>([['col2', 100]]);
+  const newProps = { ...props, resizedColumnWidths };
+  rerender(<DataGrid {...newProps} />);
   expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 100px' });
 });

--- a/website/Nav.tsx
+++ b/website/Nav.tsx
@@ -126,6 +126,9 @@ export default function Nav({ direction, onDirectionChange }: Props) {
       <NavLink to="/scroll-to-cell" end className={getActiveClassname}>
         Scroll To Cell
       </NavLink>
+      <NavLink to="/save-column-widths" end className={getActiveClassname}>
+        Save Column Widths
+      </NavLink>
       <NavLink to="/tree-view" end className={getActiveClassname}>
         Tree View
       </NavLink>

--- a/website/demos/SaveColumnWidths.tsx
+++ b/website/demos/SaveColumnWidths.tsx
@@ -1,0 +1,155 @@
+import { useState } from 'react';
+
+import DataGrid from '../../src';
+import type { Column } from '../../src';
+import { renderCoordinates } from './renderers';
+import type { Props } from './types';
+
+type Row = number;
+const rows: readonly Row[] = [...Array(10).keys()];
+
+const columns: Column<Row>[] = [];
+
+const defaultWidth = 100;
+
+for (let i = 0; i < 6; i++) {
+  const key = String(i);
+  columns.push({
+    key,
+    name: key,
+    renderCell: renderCoordinates,
+    resizable: true,
+    width: defaultWidth
+  });
+}
+
+function restoreColumnWidths() {
+  let columnWidths = new Map<string, number>();
+  const columnWidthsStr = localStorage.getItem('columnWidths');
+  if (!columnWidthsStr) return columnWidths;
+  try {
+    const columnWidthsParsed = JSON.parse(columnWidthsStr);
+    if (Array.isArray(columnWidthsParsed)) {
+      columnWidths = new Map<string, number>(columnWidthsParsed);
+    }
+  } catch {
+    // ignore errors
+  }
+  return columnWidths;
+}
+
+function getResizedColumnWidths(columnWidths: Map<string, number>) {
+  const resizedColumnWidths = new Map<string, number>();
+  columnWidths.forEach((width, columnKey) => {
+    if (width !== defaultWidth) {
+      resizedColumnWidths.set(columnKey, width);
+    }
+  });
+  return resizedColumnWidths;
+}
+
+let savedColumnWidths = new Map<string, number>();
+
+function saveColumnWidths(columnWidths: Map<string, number>) {
+  savedColumnWidths = getResizedColumnWidths(columnWidths);
+  if (savedColumnWidths.size > 0) {
+    localStorage.setItem('columnWidths', JSON.stringify(Array.from(savedColumnWidths.entries())));
+  } else {
+    localStorage.removeItem('columnWidths');
+  }
+}
+
+const undoRedoStack: Array<{ columnKey: string; prevWidth: number; newWidth: number }> = [];
+
+export default function SaveColumnWidths({ direction }: Props) {
+  const [columnWidths, setColumnWidths] = useState<Map<string, number>>(restoreColumnWidths());
+  const [undoRedoIndex, setUndoRedoIndex] = useState(0);
+
+  function handleUndo() {
+    const { columnKey, prevWidth } = undoRedoStack[undoRedoIndex - 1];
+    setColumnWidths((widths) => {
+      const newWidths = new Map(widths);
+      newWidths.set(columnKey, prevWidth);
+      saveColumnWidths(newWidths);
+      return newWidths;
+    });
+    setUndoRedoIndex((index) => --index);
+  }
+
+  function handleRedo() {
+    const { columnKey, newWidth } = undoRedoStack[undoRedoIndex];
+    setColumnWidths((widths) => {
+      const newWidths = new Map(widths);
+      newWidths.set(columnKey, newWidth);
+      saveColumnWidths(newWidths);
+      return newWidths;
+    });
+    setUndoRedoIndex((index) => ++index);
+  }
+
+  function handleReset() {
+    setColumnWidths((widths) => {
+      const newWidths = new Map(widths);
+      newWidths.forEach((width, columnKey) => {
+        newWidths.set(columnKey, defaultWidth);
+      });
+      saveColumnWidths(newWidths);
+      return newWidths;
+    });
+    undoRedoStack.splice(0, undoRedoStack.length);
+    setUndoRedoIndex(0);
+  }
+
+  function handleColumnResize(idx: number, width: number, isComplete?: boolean) {
+    const columnKey = String(idx);
+    columnWidths.set(columnKey, width);
+
+    if (isComplete) {
+      // clear redo items
+      if (undoRedoIndex < undoRedoStack.length)
+        undoRedoStack.splice(undoRedoIndex, undoRedoStack.length - undoRedoIndex);
+      // push undo item
+      undoRedoStack.push({
+        columnKey,
+        prevWidth: savedColumnWidths.get(columnKey) ?? defaultWidth,
+        newWidth: width
+      });
+      setUndoRedoIndex((index) => ++index);
+      // save widths to local storage
+      saveColumnWidths(columnWidths);
+    }
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex' }}>
+        <button style={{ margin: 5 }} disabled={undoRedoIndex === 0} onClick={handleUndo}>
+          Undo Column Width Change
+        </button>
+        <button
+          style={{ margin: 5 }}
+          disabled={undoRedoIndex === undoRedoStack.length}
+          onClick={handleRedo}
+        >
+          Redo Column Width Change
+        </button>
+        <button
+          style={{ margin: 5 }}
+          disabled={getResizedColumnWidths(columnWidths).size === 0}
+          onClick={handleReset}
+        >
+          Reset Column Widths
+        </button>
+      </div>
+      <DataGrid
+        columns={columns}
+        rows={rows}
+        resizedColumnWidths={columnWidths}
+        onColumnResize={handleColumnResize}
+        className="fill-grid"
+        style={{ resize: 'both' }}
+        direction={direction}
+      />
+    </div>
+  );
+}

--- a/website/root.tsx
+++ b/website/root.tsx
@@ -23,6 +23,7 @@ import NoRows from './demos/NoRows';
 import ResizableGrid from './demos/Resizable';
 import RowGrouping from './demos/RowGrouping';
 import RowsReordering from './demos/RowsReordering';
+import SaveColumnWidths from './demos/SaveColumnWidths';
 import ScrollToCell from './demos/ScrollToCell';
 import TreeView from './demos/TreeView';
 import VariableRowHeight from './demos/VariableRowHeight';
@@ -64,6 +65,7 @@ function Root() {
           <Route path="no-rows" element={<NoRows direction={direction} />} />
           <Route path="resizable-grid" element={<ResizableGrid direction={direction} />} />
           <Route path="rows-reordering" element={<RowsReordering direction={direction} />} />
+          <Route path="save-column-widths" element={<SaveColumnWidths direction={direction} />} />
           <Route path="scroll-to-cell" element={<ScrollToCell direction={direction} />} />
           <Route path="tree-view" element={<TreeView direction={direction} />} />
           <Route path="variable-row-height" element={<VariableRowHeight direction={direction} />} />


### PR DESCRIPTION
In our application, like many table-oriented applications, column widths are considered part of the user state and must be preserved across sessions. In the current implementation of resizable columns in `react-data-grid`, the widths of resized columns are maintained in React state internal to RDG. Clients have the ability to observe column width changes via the `onColumnResize` property, but there isn't a good way to pass those resized column widths back into RDG. This PR:
- adds a new `resizedColumnWidths` property to the `DataGrid` which allows clients to pass in column widths.
- adds a new `isComplete` property to the `onColumnResize` callback so that clients can determine when a resize operation has been completed.
- adds a vite test for client-provided columns widths.
- adds a `Save Column Widths` demo which demonstrates
    - save/restore of column widths across sessions via localstorage.
    - undo/redo of column width changes within a session.