### PR TITLE
Export `textEditorClassname`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { DataGridDefaultRenderersProvider } from './DataGridDefaultRenderersProv
 export { default as Row } from './Row';
 export * from './Columns';
 export * from './cellRenderers';
-export { default as textEditor } from './editors/textEditor';
+export { default as textEditor, textEditorClassname } from './editors/textEditor';
 export { default as renderHeaderCell } from './renderHeaderCell';
 export { renderSortIcon, renderSortPriority } from './sortStatus';
 export { useRowSelection } from './hooks';


### PR DESCRIPTION
In our application, we use our own custom cell text editor with some application-specific behavior built into it, but we want to make use of the styling of the default cell text editor. Copying the styles would be inelegant and error-prone and would not allow us to take advantage of any styling changes moving forward. Exporting the `textEditorClassname` that is used to style the default cell text editor allows clients to build application-specific cell text editors that can still take advantage of the default stying of the built-in cell text editor. CODAP has been using this approach via `patch-package` for some time now. This PR just makes it more visible. 