### PR TITLE
Save column width tweaks

### DIFF
--- a/src/DataGrid.tsx
+++ b/src/DataGrid.tsx
@@ -142,9 +142,9 @@ export interface DataGridProps<R, SR = unknown, K extends Key = Key> extends Sha
    */
   summaryRowHeight?: Maybe<number>;
   /**
-   * The client-managed width of each resized column in pixels
+   * The client-managed width of each column in pixels
    */
-  resizedColumnWidths?: ReadonlyMap<string, number>;
+  columnWidths?: ReadonlyMap<string, number>;
 
   /**
    * Feature props
@@ -219,7 +219,7 @@ function DataGrid<R, SR, K extends Key>(
     rowHeight: rawRowHeight,
     headerRowHeight: rawHeaderRowHeight,
     summaryRowHeight: rawSummaryRowHeight,
-    resizedColumnWidths: rawResizedColumnWidths,
+    columnWidths: rawColumnWidths,
     // Feature props
     selectedRows,
     onSelectedRowsChange,
@@ -278,7 +278,7 @@ function DataGrid<R, SR, K extends Key>(
   const [scrollTop, setScrollTop] = useState(0);
   const [scrollLeft, setScrollLeft] = useState(0);
   const [resizedColumnWidths, setResizedColumnWidths] = useState(
-    (): ReadonlyMap<string, number> => new Map(rawResizedColumnWidths)
+    (): ReadonlyMap<string, number> => new Map(rawColumnWidths)
   );
   const [measuredColumnWidths, setMeasuredColumnWidths] = useState(
     (): ReadonlyMap<string, number> => new Map()
@@ -291,13 +291,13 @@ function DataGrid<R, SR, K extends Key>(
   const getColumnWidth = useCallback(
     (column: CalculatedColumn<R, SR>) => {
       return (
-        rawResizedColumnWidths?.get(column.key) ??
+        rawColumnWidths?.get(column.key) ??
         resizedColumnWidths.get(column.key) ??
         measuredColumnWidths.get(column.key) ??
         column.width
       );
     },
-    [measuredColumnWidths, rawResizedColumnWidths, resizedColumnWidths]
+    [measuredColumnWidths, rawColumnWidths, resizedColumnWidths]
   );
 
   const [gridRef, gridWidth, gridHeight] = useGridDimensions();

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -135,7 +135,9 @@ export default function HeaderCell<R, SR>({
 
     function onLostPointerCapture() {
       // let client know that resize is complete
-      onColumnResize(column, lastWidth, true);
+      if (lastWidth > 0) {
+        onColumnResize(column, lastWidth, true);
+      }
       currentTarget.removeEventListener('pointermove', onPointerMove);
       currentTarget.removeEventListener('lostpointercapture', onLostPointerCapture);
     }

--- a/test/column/resizable.test.tsx
+++ b/test/column/resizable.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent } from '@testing-library/react';
 
-import type { Column } from '../../src';
+import type { Column, DataGridProps } from '../../src';
 import DataGrid from '../../src';
 import { resizeHandleClassname } from '../../src/HeaderCell';
 import { getGrid, getHeaderCells, setup } from '../utils';
@@ -110,8 +110,8 @@ test('client can update columns widths', () => {
   const props = { columns, rows: [] };
   const { rerender } = setup(props);
   expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 200px' });
-  const resizedColumnWidths = new Map<string, number>([['col2', 100]]);
-  const newProps = { ...props, resizedColumnWidths };
+  const columnWidths = new Map<string, number>([['col2', 100]]);
+  const newProps: DataGridProps<Row> = { ...props, columnWidths };
   rerender(<DataGrid {...newProps} />);
   expect(getGrid()).toHaveStyle({ gridTemplateColumns: '100px 100px' });
 });

--- a/website/demos/SaveColumnWidths.tsx
+++ b/website/demos/SaveColumnWidths.tsx
@@ -144,7 +144,7 @@ export default function SaveColumnWidths({ direction }: Props) {
       <DataGrid
         columns={columns}
         rows={rows}
-        resizedColumnWidths={columnWidths}
+        columnWidths={columnWidths}
         onColumnResize={handleColumnResize}
         className="fill-grid"
         style={{ resize: 'both' }}


### PR DESCRIPTION
- Don't call `onResizeColumn` with zero widths
- Rename `resizedColumnWidths` to `columnWidths` in `DataGridProps`